### PR TITLE
set DateTime zone to Europe/Istanbul

### DIFF
--- a/components/row.tsx
+++ b/components/row.tsx
@@ -66,7 +66,7 @@ export default function Row({
   let yerCity = location.split(" ")[1].trim();
   yerCity = yerCity.replace("(", "").replace(")", "");
 
-  const relativeDate = DateTime.fromSQL(date).toRelative({
+  const relativeDate = DateTime.fromSQL(date, { zone: "Europe/Istanbul" }).toRelative({
     locale: "tr",
   });
 


### PR DESCRIPTION
AFAD publishes earthquake date in Istanbul timezone. This looks like future from western timezones( Ex: Germany)

<img width="911" alt="image" src="https://user-images.githubusercontent.com/24354719/220223278-ae76d670-cdbe-4c0d-9a70-4fa2f9a1d84b.png">

The locale: "tr" option in toRelative method only effects the display language. We can pass zone to fromSQL method based on this example:
https://github.com/moment/luxon/blob/master/docs/zones.md#creating-datetimes-in-a-zone

It looks correct after this zone settings.
<img width="853" alt="image" src="https://user-images.githubusercontent.com/24354719/220223610-0cb8a51e-e905-4dbb-abc8-6027365bb7c2.png">
