### PR TITLE
Show the location name for sea earthquakes

### DIFF
--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -32,16 +32,13 @@ export default async function handler(req: NextRequest) {
         location: {
           selector: "td:nth-child(7)",
           transform: (value) => {
-            const [_city, _district] = (value as string)
+            const [city, district] = (value as string)
               .replace(/([()])/g, "")
               .split(" ").reverse()
 
-            const city = _city || _district;
-            const district = _city ? _district : null;
-
             return {
-              district,
               city,
+              district,
             };
           },
         },

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -28,12 +28,13 @@ export default async function handler(req: NextRequest) {
         },
         type: "td:nth-child(5)",
         magnitude: "td:nth-child(6) | float",
+        // "Ege Denizi - [40.26 km] Datça (Muğla)" or "Türkoğlu (Kahramanmaraş)"
         location: {
           selector: "td:nth-child(7)",
           transform: (value) => {
-            const [_district, _city] = (value as string)
+            const [_city, _district] = (value as string)
               .replace(/([()])/g, "")
-              .split(" ");
+              .split(" ").reverse()
 
             const city = _city || _district;
             const district = _city ? _district : null;


### PR DESCRIPTION
The earthqueakes that happening in the sea look different than normal earthquakes in strings that are returned via api.
```
Ege Denizi - Kuşadası Körfezi - [08.46 km] Kuşadası (Aydın)
Göksun (Kahramanmaraş)
``` 

They look like below in the app
![Screenshot 2023-02-22 at 14 51 42](https://user-images.githubusercontent.com/447588/220612940-8c672c0e-19cf-419e-ad4d-9316bdb09656.png)

but after this fix, it would look like 

<img width="924" alt="Screenshot 2023-02-22 at 14 51 45" src="https://user-images.githubusercontent.com/447588/220613126-60bf205e-7cc6-4672-8226-70b36060ca58.png">

I think we can add a wave emoji for sea earthquakes in the future.
