### PR TITLE
fix: layout shifting on scrollable content

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="tr" className={`scroll-smooth ${inter.variable}`}>
+    <html lang="tr" className={`scroll-smooth ${inter.variable} overflow-y-scroll`}>
       <body className="bg-white leading-normal text-zinc-600 antialiased dark:bg-zinc-900 dark:text-zinc-400">
         <main>{children}</main>
         <AnalyticsWrapper />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,7 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-:root {
-    overflow-y: scroll;
-}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+    overflow-y: scroll;
+}


### PR DESCRIPTION
I always use `overflow-y: scroll` on root because hate layout shifting on scroll visibility changes. So I wanted to add that to this project. You can see the difference here:

https://user-images.githubusercontent.com/23298031/221022982-7c26ab23-2594-4edd-adcb-d2f3798372f7.mp4

