### PR TITLE
fix: each child in a list should have a unique key prop warning and deprecated zustand import

### DIFF
--- a/components/list.tsx
+++ b/components/list.tsx
@@ -42,8 +42,8 @@ export default function List() {
           return (
             <div key={key}>
               {rows.length > 0 && <Day date={key} />}
-              {rows.map((row: Item) => (
-                <Row key={row.id} item={row} />
+              {rows.map((row: Item, rowIndex) => (
+                <Row key={`${rowIndex}`} item={row} />
               ))}
             </div>
           );

--- a/stores/list.ts
+++ b/stores/list.ts
@@ -1,5 +1,5 @@
 import { DateTime } from "luxon";
-import create from "zustand";
+import { create } from "zustand";
 
 import { Data, DataByDay, Filter, Item } from "@/lib/types";
 


### PR DESCRIPTION
## Bu PR neyi çözüyor?

- [ X ] `<List>` bileşeni içerisinde render edilen `Row` id'leri unique olmadığından dolayı konsolda gösterilen hata fixlendi.
- [ X ] Zustand içerisinde deprecated olan import yöntemi ve onunla birlikte gelen uyarı mesajları ardından fixlendi. 